### PR TITLE
#20 노드 좌표+정보 조회 API 구현

### DIFF
--- a/src/main/java/hongik/map/honggildong/domain/facility/entity/Floor.java
+++ b/src/main/java/hongik/map/honggildong/domain/facility/entity/Floor.java
@@ -1,5 +1,5 @@
 package hongik.map.honggildong.domain.facility.entity;
 
 public enum Floor {
-    B5,B4,B3,B2,B1,F1,F2,F3,F4,F5,F6,F7,F8,F9,F10,F11,F12;
+    B5,B4,B3,B2,B1,LOBBY,F1,F2,F3,F4,F5,F6,F7,F8,F9,F10,F11,F12;
 }

--- a/src/main/java/hongik/map/honggildong/domain/node/controller/NodeController.java
+++ b/src/main/java/hongik/map/honggildong/domain/node/controller/NodeController.java
@@ -1,0 +1,25 @@
+package hongik.map.honggildong.domain.node.controller;
+
+import hongik.map.honggildong.domain.node.dto.NodeResponseDTO;
+import hongik.map.honggildong.domain.node.service.NodeService;
+import hongik.map.honggildong.global.apiPayload.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("node")
+public class NodeController {
+
+    private final NodeService nodeService;
+
+    @GetMapping("/{nodeId}")
+    public ApiResponse<NodeResponseDTO.Coordinate> getNode(@PathVariable("nodeId") Long nodeId) {
+        NodeResponseDTO.Coordinate body = nodeService.getNodeCoordinate(nodeId);
+
+        return ApiResponse.onSuccess(body);
+    }
+}

--- a/src/main/java/hongik/map/honggildong/domain/node/controller/NodeController.java
+++ b/src/main/java/hongik/map/honggildong/domain/node/controller/NodeController.java
@@ -9,6 +9,8 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.List;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("node")
@@ -19,6 +21,13 @@ public class NodeController {
     @GetMapping("/{nodeId}")
     public ApiResponse<NodeResponseDTO.Coordinate> getNode(@PathVariable("nodeId") Long nodeId) {
         NodeResponseDTO.Coordinate body = nodeService.getNodeCoordinate(nodeId);
+
+        return ApiResponse.onSuccess(body);
+    }
+
+    @GetMapping("/all")
+    public ApiResponse<List<NodeResponseDTO.Coordinate>> getAllNodes() {
+        List<NodeResponseDTO.Coordinate> body = nodeService.getAllNodeCoordinates();
 
         return ApiResponse.onSuccess(body);
     }

--- a/src/main/java/hongik/map/honggildong/domain/node/converter/NodeConverter.java
+++ b/src/main/java/hongik/map/honggildong/domain/node/converter/NodeConverter.java
@@ -1,0 +1,17 @@
+package hongik.map.honggildong.domain.node.converter;
+
+import hongik.map.honggildong.domain.node.dto.NodeResponseDTO;
+import hongik.map.honggildong.domain.node.entity.Node;
+
+public class NodeConverter {
+
+    public static NodeResponseDTO.Coordinate toCoordinateDTO(Node node) {
+        return NodeResponseDTO.Coordinate.builder()
+                .nodeId(node.getId())
+                .name(node.getName())
+                .latitude(node.getLatitude())
+                .longitude(node.getLongitude())
+                .nodeCode(node.getCode())
+                .build();
+    }
+}

--- a/src/main/java/hongik/map/honggildong/domain/node/dto/NodeResponseDTO.java
+++ b/src/main/java/hongik/map/honggildong/domain/node/dto/NodeResponseDTO.java
@@ -1,0 +1,21 @@
+package hongik.map.honggildong.domain.node.dto;
+
+import hongik.map.honggildong.domain.node.entity.NodeCode;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class NodeResponseDTO {
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Getter
+    public static class Coordinate{
+        private Long nodeId;
+        private Double latitude;
+        private Double longitude;
+        private String name;
+        private NodeCode nodeCode;
+    }
+}

--- a/src/main/java/hongik/map/honggildong/domain/node/entity/Node.java
+++ b/src/main/java/hongik/map/honggildong/domain/node/entity/Node.java
@@ -6,12 +6,14 @@ import jakarta.annotation.Nullable;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Builder
 @Entity
 @NoArgsConstructor
 @AllArgsConstructor
+@Getter
 public class Node extends BaseEntity {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/hongik/map/honggildong/domain/node/repository/NodeRepository.java
+++ b/src/main/java/hongik/map/honggildong/domain/node/repository/NodeRepository.java
@@ -1,0 +1,10 @@
+package hongik.map.honggildong.domain.node.repository;
+
+import hongik.map.honggildong.domain.node.entity.Node;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+
+@Repository
+public interface NodeRepository extends JpaRepository<Node, Long> {
+}

--- a/src/main/java/hongik/map/honggildong/domain/node/service/NodeService.java
+++ b/src/main/java/hongik/map/honggildong/domain/node/service/NodeService.java
@@ -2,6 +2,10 @@ package hongik.map.honggildong.domain.node.service;
 
 import hongik.map.honggildong.domain.node.dto.NodeResponseDTO;
 
+import java.util.List;
+
 public interface NodeService {
     NodeResponseDTO.Coordinate getNodeCoordinate(Long nodeId);
+
+    List<NodeResponseDTO.Coordinate> getAllNodeCoordinates();
 }

--- a/src/main/java/hongik/map/honggildong/domain/node/service/NodeService.java
+++ b/src/main/java/hongik/map/honggildong/domain/node/service/NodeService.java
@@ -1,0 +1,7 @@
+package hongik.map.honggildong.domain.node.service;
+
+import hongik.map.honggildong.domain.node.dto.NodeResponseDTO;
+
+public interface NodeService {
+    NodeResponseDTO.Coordinate getNodeCoordinate(Long nodeId);
+}

--- a/src/main/java/hongik/map/honggildong/domain/node/service/NodeServiceImpl.java
+++ b/src/main/java/hongik/map/honggildong/domain/node/service/NodeServiceImpl.java
@@ -1,0 +1,26 @@
+package hongik.map.honggildong.domain.node.service;
+
+
+import hongik.map.honggildong.domain.node.converter.NodeConverter;
+import hongik.map.honggildong.domain.node.dto.NodeResponseDTO;
+import hongik.map.honggildong.domain.node.entity.Node;
+import hongik.map.honggildong.domain.node.repository.NodeRepository;
+import hongik.map.honggildong.global.apiPayload.code.status.ErrorStatus;
+import hongik.map.honggildong.global.apiPayload.exception.GeneralException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class NodeServiceImpl implements NodeService {
+
+    private final NodeRepository nodeRepository;
+
+    @Override
+    public NodeResponseDTO.Coordinate getNodeCoordinate(Long nodeId) {
+
+        Node node = nodeRepository.findById(nodeId).orElseThrow(()->new GeneralException(ErrorStatus.NODE_NOT_FOUND));
+
+        return NodeConverter.toCoordinateDTO(node);
+    }
+}

--- a/src/main/java/hongik/map/honggildong/domain/node/service/NodeServiceImpl.java
+++ b/src/main/java/hongik/map/honggildong/domain/node/service/NodeServiceImpl.java
@@ -10,6 +10,9 @@ import hongik.map.honggildong.global.apiPayload.exception.GeneralException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class NodeServiceImpl implements NodeService {
@@ -22,5 +25,12 @@ public class NodeServiceImpl implements NodeService {
         Node node = nodeRepository.findById(nodeId).orElseThrow(()->new GeneralException(ErrorStatus.NODE_NOT_FOUND));
 
         return NodeConverter.toCoordinateDTO(node);
+    }
+
+    @Override
+    public List<NodeResponseDTO.Coordinate> getAllNodeCoordinates() {
+
+        List<Node> nodes = nodeRepository.findAll();
+        return nodes.stream().map(NodeConverter::toCoordinateDTO).toList();
     }
 }

--- a/src/main/java/hongik/map/honggildong/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/hongik/map/honggildong/global/apiPayload/code/status/ErrorStatus.java
@@ -18,7 +18,10 @@ public enum ErrorStatus implements BaseCode {
 
 
     // 멤버 관련 응답
-    EMAIL_ALREADY_EXISTS(HttpStatus.CONFLICT,"MEMBER409","이미 존재하는 이메일입니다.");
+    EMAIL_ALREADY_EXISTS(HttpStatus.CONFLICT,"MEMBER409","이미 존재하는 이메일입니다."),
+
+    //노드 관련 응답
+    NODE_NOT_FOUND(HttpStatus.NOT_FOUND,"NODE404","존재하지 않는 노드입니다.");
 
     private final HttpStatus httpStatus;
     private final String code;


### PR DESCRIPTION
## 🍀 Related Issue

> #20 

## 🍀 Work Details

> 지금까지 모아둔 데이터셋의 좌표 정확도를 테스트하기 위해 좌표 조회용 API를 임시로 만듭니다.

- [x] 특정 노드 좌표 조회 API
- [x] 모든 노드 좌표 리스트 조회 API

## 🍀 Review Requirement

> 궁금한 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 노드 좌표 단건 조회(아이디 기준)와 전체 조회 API를 추가했습니다.
  - 응답에 노드 ID, 이름, 위도/경도, 노드 코드를 포함해 지도를 연동하기 쉬워졌습니다.
  - 존재하지 않는 노드 요청 시 404 상태와 명확한 오류 메시지를 반환합니다.
  - 건물 층 목록에 LOBBY가 추가되어 층 선택이 더 정확해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->